### PR TITLE
feat: add flexibility to version regex pattern.

### DIFF
--- a/options.hpp
+++ b/options.hpp
@@ -54,7 +54,7 @@ private:
 
 public:
     static std::string getSemanticVersion() {
-        static const std::regex pattern{R"(Version-([0-9]+\.[0-9]+\.[0-9]+))"};
+        static const std::regex pattern{R"((?:^|-|n|v|V)([0-9]+\.[0-9]+\.[0-9]+))"};
         std::smatch match;
         const std::string tag{APP_VERSION};
         if (std::regex_search(tag, match, pattern) && match.size() > 1) {


### PR DESCRIPTION
Add flexibility to the version REGEX pattern:

1.2.3 -> Matches. ^ matches the start of the string.
-1.2.3 -> Matches. - is matched.
v1.2.3 -> Matches. v is matched.
V1.2.3 -> Matches. V is matched.
version1.2.3 -> Matches. n is matched.
version-1.2.3 -> Matches. - is matched before the version number.
a1.2.3 -> Does not match, because it does not start with ^, -, or v.