### PR TITLE
Fix Title not displaying issue

### DIFF
--- a/event_preprocessor.cpp
+++ b/event_preprocessor.cpp
@@ -71,6 +71,7 @@ bool EventPreProcessor::processEvent(cxxmidi::Event& event, const Options& optio
         }
         
         if (0 == totalTrackTicks_) {  // Processing for Time Zero Meta events
+            processTrackNameEvent(event);
             processTimeSignatureEvent(event);
             processTempoEvent(event, options);
             processKeySignatureEvent(event);


### PR DESCRIPTION
The title was displaying as an empty string ""

Add a call to processTrackNameEvent(event) where the Meta Events are processed.